### PR TITLE
(ENI-56) Blocks the org_id get query string on the my-account page unless the user has the 'manage_options' capability.

### DIFF
--- a/includes/class-simple-table.php
+++ b/includes/class-simple-table.php
@@ -12,6 +12,10 @@ class Simple_Table_Filter {
             return [];
         }
 
+        if ( ! user_can( wp_get_current_user(), 'manage_options' )) {
+            return [];
+        }
+
         $this->_org_id = $org_id;
 
 	    // Sample data from PHP array (replace with DB query results as needed).


### PR DESCRIPTION
Pertains to ENI-56 in JIRA